### PR TITLE
setup: update pyannote.audio requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ hmmlearn >=0.2.7,<0.3
 huggingface_hub >= 0.7,<0.9
 networkx >= 2.6,<3.0
 omegaconf >=2.1,<3.0
+pyannote.audio >=2.1.1
 pyannote.core >=4.4,<5.0
 pyannote.database >=4.1.1,<5.0
 pyannote.metrics >=3.2,<4.0
@@ -20,5 +21,3 @@ torch_audiomentations >= 0.11.0
 torchaudio >=0.10,<1.0
 torchmetrics >=0.6,<1.0
 typing_extensions
-git+https://github.com/pyannote/pyannote-audio.git@develop#egg=pyannote.audio
-# git+ssh://git@gitlab.cognitive-ml.fr:1022/htiteux/brouhaha-vtc.git#egg=pyannote.db.brouhaha


### PR DESCRIPTION
pyannote.audio 2.1.1 has just been released.
Using a  proper release should be more future-proof than relying on the `develop` branch