### PR TITLE
Update requirements.txt to avoid NumPy.nan issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyannote.audio==3.2.0
+pyannote.audio==3.3.2


### PR DESCRIPTION
See issue here:
https://github.com/huggingface/dataspeech/issues/41

In NumPy v2 and above, the use of numpy.NaN has been removed, and numpy.nan is required.
The use of np.NaN was raised as an issue in pyannote.audio and fixed 11/09/2024. (https://github.com/pyannote/pyannote-audio/issues/1758)

As brouhaha-vad specifies pyannote.audio version 3.2.0, this fix is not included and as such crashes on any system running NumPy version 2 or above.
Changing the requirement to pyannote.audio = 3.3.2 means this error is avoided, and doesn't appear to have any detrimental effect on the operation of the model.