### PR TITLE
Update requirements to remove version constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyannote.audio==3.3.0
-numpy==1.24.4
+pyannote.audio
+numpy


### PR DESCRIPTION
Removed specific version constraints for pyannote.audio and numpy. By removing these, we can use the model on python 12.x